### PR TITLE
binding.gyp: fix missing comma

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -7,7 +7,7 @@
         "src"
       ],
       "sources": [
-        "src/binding.cc"
+        "src/binding.cc",
         "src/parser.c",
         "src/scanner.c",
       ],


### PR DESCRIPTION
Fixes `npm install`. It would error out with the following message:

```
tree-sitter-teal@0.0.1 install /home/patrick/Code/vscode-teal/node_modules/tree-sitter-teal
> node-gyp rebuild

make: Entering directory '/home/patrick/Code/vscode-teal/node_modules/tree-sitter-teal/build'
make: *** No rule to make target 'Release/obj.target/tree_sitter_teal_binding/src/binding.ccsrc/parser.o', needed by 'Release/obj.target/tree_sitter_teal_binding.node'.  Stop.
make: Leaving directory '/home/patrick/Code/vscode-teal/node_modules/tree-sitter-teal/build'
```