### PR TITLE
Disambiguate record entries

### DIFF
--- a/corpus/enum_block.txt
+++ b/corpus/enum_block.txt
@@ -9,7 +9,7 @@ end
 
 (program
   (type_declaration
-    (type_name)
+    (identifier)
     (enum_body)))
 
 ================================================================================
@@ -25,7 +25,7 @@ end
 
 (program
   (type_declaration
-    (type_name)
+    (identifier)
     (enum_body
       (string
         (string_content))

--- a/corpus/record_block.txt
+++ b/corpus/record_block.txt
@@ -9,8 +9,8 @@ end
 
 (program
   (type_declaration
-    (type_name)
-    (anon_record
+    name: (identifier)
+    value: (anon_record
       record_body: (record_body))))
 
 ================================================================================
@@ -40,15 +40,15 @@ end
 
 (program
   (type_declaration
-    (type_name)
-    (anon_record
+    name: (identifier)
+    value: (anon_record
       record_body: (record_body
-        (record_entry
+        (field
           key: (identifier)
           type: (table_type
             value_type: (simple_type
               name: (identifier))))
-        (record_entry
+        (field
           key: (identifier)
           type: (simple_type
             name: (identifier)))))))
@@ -67,18 +67,18 @@ end
 
 (program
   (type_declaration
-    (type_name)
-    (anon_record
+    name: (identifier)
+    value: (anon_record
       record_body: (record_body
         (record_array_type
           (simple_type
             name: (identifier)))
-        (record_entry
+        (field
           key: (identifier)
           type: (table_type
             value_type: (simple_type
               name: (identifier))))
-        (record_entry
+        (field
           key: (identifier)
           type: (simple_type
             name: (identifier)))))))
@@ -98,18 +98,18 @@ end
 
 (program
   (type_declaration
-    (type_name)
-    (anon_record
+    name: (identifier)
+    value: (anon_record
       record_body: (record_body
-        (record_entry
-          key: (identifier)
+        (typedef
+          name: (identifier)
           value: (anon_record
             record_body: (record_body
-              (record_entry
+              (field
                 key: (identifier)
                 type: (simple_type
                   name: (identifier))))))
-        (record_entry
+        (field
           key: (identifier)
           type: (simple_type
             name: (identifier)))))))
@@ -126,12 +126,12 @@ end
 
 (program
   (type_declaration
-    (type_name)
-    (anon_record
+    name: (identifier)
+    value: (anon_record
       (typeargs
         (identifier))
       record_body: (record_body
-        (record_entry
+        (field
           key: (identifier)
           type: (simple_type
             name: (identifier)))))))
@@ -148,10 +148,10 @@ end
 
 (program
   (type_declaration
-    (type_name)
-    (anon_record
+    name: (identifier)
+    value: (anon_record
       record_body: (record_body
-        (record_entry
+        (field
           key: (identifier)
           type: (simple_type
             name: (identifier)))))))
@@ -173,19 +173,19 @@ end
 
 (program
   (type_declaration
-    (type_name)
-    (anon_record
+    name: (identifier)
+    value: (anon_record
       record_body: (record_body
-        (record_entry
+        (field
           key: (identifier)
           type: (simple_type
             name: (identifier)))
-        (record_entry
-          key: (identifier)
+        (typedef
+          name: (identifier)
           value: (anon_record
             record_body: (record_body)))
-        (record_entry
-          key: (identifier)
+        (typedef
+          name: (identifier)
           value: (enum_body
             (string
               content: (string_content))
@@ -207,9 +207,9 @@ end
   (record_declaration
     name: (identifier)
     record_body: (record_body
-      (record_entry
-        key: (identifier)
-        value: (record_body)))))
+      (record_declaration
+        name: (identifier)
+        record_body: (record_body)))))
 
 ================================================================================
 Nested enum shorthand syntax
@@ -227,9 +227,9 @@ end
   (record_declaration
     name: (identifier)
     record_body: (record_body
-      (record_entry
-        key: (identifier)
-        value: (enum_body
+      (enum_declaration
+        name: (identifier)
+        (enum_body
           (string
             content: (string_content))
           (string
@@ -249,7 +249,7 @@ end
   (record_declaration
     name: (identifier)
     record_body: (record_body
-      (record_entry
+      (field
         key: (identifier)
         type: (simple_type
           name: (identifier))))))
@@ -268,7 +268,7 @@ end
   (record_declaration
     name: (identifier)
     record_body: (record_body
-      (record_entry
+      (field
         key: (identifier)
         type: (simple_type
           name: (identifier))))))
@@ -287,7 +287,7 @@ end
   (record_declaration
     name: (identifier)
     record_body: (record_body
-      (record_entry
+      (field
         string_key: (string
           content: (string_content))
         type: (simple_type
@@ -308,11 +308,11 @@ end
   (record_declaration
     name: (identifier)
     record_body: (record_body
-      (record_entry
-        key: (identifier)
+      (record_declaration
+        name: (identifier)
         typeargs: (typeargs
           (identifier))
-        value: (record_body)))))
+        record_body: (record_body)))))
 
 ================================================================================
 Userdata record

--- a/grammar.js
+++ b/grammar.js
@@ -214,15 +214,19 @@ module.exports = grammar({
       optional(seq("=", list($._expression)))
     ),
 
+    _type_def: $ => seq(
+        "type",
+        field("name", $.identifier),
+        "=",
+        field("value", choice(
+          $._type, $._newtype
+        ))
+    ),
+
     type_declaration: $ => choice(
       seq(
-        $.scope,
-        "type",
-        alias($.identifier, $.type_name),
-        "=",
-        choice(
-          $._type, $._newtype
-        )
+        field("scope", $.scope),
+        $._type_def,
       ),
       $.record_declaration,
       $.enum_declaration,
@@ -346,7 +350,7 @@ module.exports = grammar({
       "end"
     ),
 
-    record_entry: $ => choice(
+    record_field: $ => choice(
       seq(
         field("key", $.identifier),
         ":", field("type", $._type)
@@ -360,19 +364,13 @@ module.exports = grammar({
         field("key", alias(reserved_id, $.identifier)),
         ":", field("type", $._type)
       )),
-      seq(
-        "type", field("key", $.identifier), "=", field("value", choice($._type, $._newtype))
-      ),
-      seq(
-        "record",
-        field("key", $.identifier),
-        field("typeargs", optional($.typeargs)),
-        field("value", $.record_body),
-      ),
-      seq(
-        "enum", field("key", $.identifier),
-        field("value", $.enum_body),
-      ),
+    ),
+
+    _record_entry: $ => choice(
+        alias($.record_field, $.field),
+        alias($._type_def, $.typedef),
+        alias($._record_def, $.record_declaration),
+        alias($._enum_def, $.enum_declaration),
     ),
 
     metamethod_annotation: $ => seq(
@@ -382,7 +380,7 @@ module.exports = grammar({
     record_body: $ => seq(
       optional(seq("{", alias($._type, $.record_array_type), "}")),
       repeat(choice(
-        $.record_entry,
+        $._record_entry,
         alias("userdata", $.userdata),
         field("metamethod", alias($.metamethod_annotation, $.metamethod)),
       )),

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -68,13 +68,17 @@
   name: (identifier) @type)
 (anon_record . "record" @keyword)
 (record_body
-  (record_entry
-    . [ "record" "enum" ] @keyword
-    . key: (identifier) @type))
+  (record_declaration
+    . [ "record" ] @keyword
+    . name: (identifier) @type))
 (record_body
-  (record_entry
+  (enum_declaration
+    . [ "enum" ] @keyword
+    . name: (identifier) @type))
+(record_body
+  (typedef
     . "type" @keyword
-    . key: (identifier) @type . "="))
+    . name: (identifier) @type . "="))
 (record_body
   (metamethod "metamethod" @keyword))
 (record_body
@@ -85,7 +89,7 @@
   name: (identifier) @type)
 
 (type_declaration "type" @keyword)
-(type_declaration (type_name) @type)
+(type_declaration (identifier) @type)
 (simple_type) @type
 (type_index) @type
 (type_union "|" @operator)


### PR DESCRIPTION
It is currently somewhat difficult to tell different kinds of record entries apart. They are all a `record_entry` with a `key` and either a `type` or `value` field.

While you can figure out which kind it is by inspecting the children, I think it would be better if we don't just have a single `record_entry` kind, but instead `field`, `typedef`, `record_declaration`, and `enum_declaration`, so you can immediately tell what type of record entry it is.

I also made subrecords, enums within records, and type definitions in records more consistent with their global counterparts.